### PR TITLE
Remove empty references section from README

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -403,4 +403,3 @@ related:
     description: "Atmos is like docker-compose but for your infrastructure"
     url: "https://atmos.tools"
 contributors: [] # If included generates contribs
-references: []


### PR DESCRIPTION
## what
* Remove empty references section from README

## why
* Fix readme generation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Cleaned up README by removing an empty “references” section to improve clarity and formatting.
  * Ensured the document reads more cleanly with no stray placeholders.
  * No functional or API changes; behavior remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->